### PR TITLE
Add contact list form component and update schemas to include anchor

### DIFF
--- a/src/api/augmenter-conf/content-types/augmenter-conf/schema.json
+++ b/src/api/augmenter-conf/content-types/augmenter-conf/schema.json
@@ -22,7 +22,8 @@
         "shared.ticketing",
         "shared.rich-text-section",
         "shared.hero",
-        "shared.slider"
+        "shared.slider",
+        "shared.contact-list-form"
       ]
     }
   }

--- a/src/components/shared/contact-list-form.json
+++ b/src/components/shared/contact-list-form.json
@@ -1,0 +1,25 @@
+{
+  "collectionName": "components_shared_contact_list_forms",
+  "info": {
+    "displayName": "Contact list form"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "richtext"
+    },
+    "submit_label": {
+      "type": "string"
+    },
+    "success_message": {
+      "type": "richtext"
+    },
+    "html_anchor": {
+      "type": "string"
+    }
+  },
+  "config": {}
+}

--- a/src/components/shared/cta.json
+++ b/src/components/shared/cta.json
@@ -10,6 +10,9 @@
     },
     "url": {
       "type": "string"
+    },
+    "html_anchor": {
+      "type": "string"
     }
   },
   "config": {}

--- a/src/components/shared/hero.json
+++ b/src/components/shared/hero.json
@@ -15,6 +15,9 @@
       "type": "component",
       "component": "shared.cta",
       "repeatable": true
+    },
+    "html_anchor": {
+      "type": "string"
     }
   },
   "config": {}

--- a/src/components/shared/rich-text-section.json
+++ b/src/components/shared/rich-text-section.json
@@ -15,6 +15,9 @@
       "type": "component",
       "component": "shared.cta",
       "repeatable": true
+    },
+    "html_anchor": {
+      "type": "string"
     }
   },
   "config": {}

--- a/src/components/shared/slider.json
+++ b/src/components/shared/slider.json
@@ -17,6 +17,9 @@
       "allowedTypes": [
         "images"
       ]
+    },
+    "html_anchor": {
+      "type": "string"
     }
   }
 }

--- a/src/components/shared/ticketing.json
+++ b/src/components/shared/ticketing.json
@@ -26,6 +26,9 @@
     },
     "ticketing_url": {
       "type": "string"
+    },
+    "html_anchor": {
+      "type": "string"
     }
   },
   "config": {}

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
     "termsOfService": "YOUR_TERMS_OF_SERVICE_URL",
-    "x-generation-date": "2025-12-21T12:08:33.752Z"
+    "x-generation-date": "2025-12-21T13:02:25.110Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -7014,6 +7014,9 @@
                     },
                     {
                       "$ref": "#/components/schemas/SharedSliderComponent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/SharedContactListFormComponent"
                     }
                   ]
                 },
@@ -7023,7 +7026,8 @@
                     "shared.ticketing": "#/components/schemas/SharedTicketingComponent",
                     "shared.rich-text-section": "#/components/schemas/SharedRichTextSectionComponent",
                     "shared.hero": "#/components/schemas/SharedHeroComponent",
-                    "shared.slider": "#/components/schemas/SharedSliderComponent"
+                    "shared.slider": "#/components/schemas/SharedSliderComponent",
+                    "shared.contact-list-form": "#/components/schemas/SharedContactListFormComponent"
                   }
                 }
               },
@@ -7110,6 +7114,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/SharedSliderComponent"
+                },
+                {
+                  "$ref": "#/components/schemas/SharedContactListFormComponent"
                 }
               ]
             },
@@ -7119,7 +7126,8 @@
                 "shared.ticketing": "#/components/schemas/SharedTicketingComponent",
                 "shared.rich-text-section": "#/components/schemas/SharedRichTextSectionComponent",
                 "shared.hero": "#/components/schemas/SharedHeroComponent",
-                "shared.slider": "#/components/schemas/SharedSliderComponent"
+                "shared.slider": "#/components/schemas/SharedSliderComponent",
+                "shared.contact-list-form": "#/components/schemas/SharedContactListFormComponent"
               }
             }
           },
@@ -7189,6 +7197,9 @@
                       },
                       {
                         "$ref": "#/components/schemas/SharedSliderComponent"
+                      },
+                      {
+                        "$ref": "#/components/schemas/SharedContactListFormComponent"
                       }
                     ]
                   },
@@ -7198,7 +7209,8 @@
                       "shared.ticketing": "#/components/schemas/SharedTicketingComponent",
                       "shared.rich-text-section": "#/components/schemas/SharedRichTextSectionComponent",
                       "shared.hero": "#/components/schemas/SharedHeroComponent",
-                      "shared.slider": "#/components/schemas/SharedSliderComponent"
+                      "shared.slider": "#/components/schemas/SharedSliderComponent",
+                      "shared.contact-list-form": "#/components/schemas/SharedContactListFormComponent"
                     }
                   }
                 },
@@ -7446,6 +7458,9 @@
           },
           "url": {
             "type": "string"
+          },
+          "html_anchor": {
+            "type": "string"
           }
         }
       },
@@ -7484,6 +7499,9 @@
           },
           "ticketing_url": {
             "type": "string"
+          },
+          "html_anchor": {
+            "type": "string"
           }
         }
       },
@@ -7510,6 +7528,9 @@
             "items": {
               "$ref": "#/components/schemas/SharedCtaComponent"
             }
+          },
+          "html_anchor": {
+            "type": "string"
           }
         }
       },
@@ -7536,6 +7557,9 @@
             "items": {
               "$ref": "#/components/schemas/SharedCtaComponent"
             }
+          },
+          "html_anchor": {
+            "type": "string"
           }
         }
       },
@@ -7685,6 +7709,38 @@
                 }
               }
             }
+          },
+          "html_anchor": {
+            "type": "string"
+          }
+        }
+      },
+      "SharedContactListFormComponent": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "__component": {
+            "type": "string",
+            "enum": [
+              "shared.contact-list-form"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "submit_label": {
+            "type": "string"
+          },
+          "success_message": {
+            "type": "string"
+          },
+          "html_anchor": {
+            "type": "string"
           }
         }
       },

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -13,12 +13,27 @@ export interface SharedCommonUrl extends Struct.ComponentSchema {
   };
 }
 
+export interface SharedContactListForm extends Struct.ComponentSchema {
+  collectionName: 'components_shared_contact_list_forms';
+  info: {
+    displayName: 'Contact list form';
+  };
+  attributes: {
+    description: Schema.Attribute.RichText;
+    html_anchor: Schema.Attribute.String;
+    submit_label: Schema.Attribute.String;
+    success_message: Schema.Attribute.RichText;
+    title: Schema.Attribute.String;
+  };
+}
+
 export interface SharedCta extends Struct.ComponentSchema {
   collectionName: 'components_shared_ctas';
   info: {
     displayName: 'CTA';
   };
   attributes: {
+    html_anchor: Schema.Attribute.String;
     title: Schema.Attribute.String;
     url: Schema.Attribute.String;
   };
@@ -32,6 +47,7 @@ export interface SharedHero extends Struct.ComponentSchema {
   attributes: {
     content: Schema.Attribute.RichText;
     cta: Schema.Attribute.Component<'shared.cta', true>;
+    html_anchor: Schema.Attribute.String;
     title: Schema.Attribute.String;
   };
 }
@@ -78,6 +94,7 @@ export interface SharedRichTextSection extends Struct.ComponentSchema {
   };
   attributes: {
     CTA: Schema.Attribute.Component<'shared.cta', true>;
+    html_anchor: Schema.Attribute.String;
     text: Schema.Attribute.RichText;
     title: Schema.Attribute.String;
   };
@@ -107,6 +124,7 @@ export interface SharedSlider extends Struct.ComponentSchema {
   };
   attributes: {
     files: Schema.Attribute.Media<'images', true>;
+    html_anchor: Schema.Attribute.String;
     title: Schema.Attribute.String;
   };
 }
@@ -132,6 +150,7 @@ export interface SharedTicketing extends Struct.ComponentSchema {
   };
   attributes: {
     CTA: Schema.Attribute.Component<'shared.cta', true>;
+    html_anchor: Schema.Attribute.String;
     text_after: Schema.Attribute.RichText;
     text_before: Schema.Attribute.RichText;
     ticketing_url: Schema.Attribute.String;
@@ -144,6 +163,7 @@ declare module '@strapi/strapi' {
   export module Public {
     export interface ComponentSchemas {
       'shared.common-url': SharedCommonUrl;
+      'shared.contact-list-form': SharedContactListForm;
       'shared.cta': SharedCta;
       'shared.hero': SharedHero;
       'shared.media': SharedMedia;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -521,6 +521,7 @@ export interface ApiAugmenterConfAugmenterConf extends Struct.SingleTypeSchema {
         'shared.rich-text-section',
         'shared.hero',
         'shared.slider',
+        'shared.contact-list-form',
       ]
     >;
     createdAt: Schema.Attribute.DateTime;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `shared.contact-list-form` component and introduces `html_anchor` to several shared components, updating the augmenter config, API docs, and generated TypeScript types.
> 
> - **CMS Schema (Strapi)**:
>   - **Dynamic Zone**: Include `shared.contact-list-form` in `api/augmenter-conf` `content` dynamic zone.
>   - **New Component**: Add `shared.contact-list-form` with `title`, `description`, `submit_label`, `success_message`, `html_anchor`.
>   - **Anchors**: Add `html_anchor` to `shared.cta`, `shared.hero`, `shared.rich-text-section`, `shared.slider`, `shared.ticketing`.
> - **API Docs**:
>   - Extend OpenAPI schemas and discriminators to include `SharedContactListFormComponent` and new `html_anchor` properties.
> - **Types**:
>   - Update generated `types/generated/components.d.ts` and `contentTypes.d.ts` to reflect new component and `html_anchor` attributes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1501afeab3d3cf2bf032de7e6ae28b06e6924953. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->